### PR TITLE
Creating NetCDF and EML output 

### DIFF
--- a/0_Function_library/metadata_functions.R
+++ b/0_Function_library/metadata_functions.R
@@ -4,120 +4,124 @@
 # see document here: https://docs.google.com/document/d/1Xxyt-1LFHCE-CBwF_qad2sWHMHJoZVJdrOyK4ydjeR0/edit
 # Following the Climate and Forecast (CF) convention, the order of dimensions for all three formats is T, Z, Y, X, E where T is time, Z, Y, and X are spatial dimensions, and E is ensemble member. In general forecasts issued at different dates or times should be stored in separate files, and thus the time dimension is the time being predicted. If multiple forecasts are placed within a single file then the issue time is the first time dimension and then the time being predicted is second.
 
-# practice data #############
-hindcast_matrix = read.csv('edi.18.3/Gechinulata_hindcasts/Gechinulata_hindcasts/AR_IC.Pa.P.O_2015-05-14.csv', stringsAsFactor = F)
-Nmc = 7500
-forecast_issue_time = as.Date('2015-05-07')
-forecast_iteration_id = uuid::UUIDgenerate()
-forecast_project_id = 'GLEON_Bayes_forecast_WG_Gloeo_uncertainty_partition_20200909'
-model_name = 'AR_IC'
-nc_name_out = 'AR_IC.Pa.P.O_2015-05-14.nc'
-
 library(ncdf4)
 library(tidyverse)
 library(EML)
 library(emld)
 library(uuid)
 library(EFIstandards)
-######
 
 #' Function to organize model output arrays into netcdf
-#' @param hindcast_matrix matrix of hindcast output; currently forecasting out 4 weeks
-#' @param Nmc number of draws / ensembles
+#' @param n_mc number of draws / ensembles
 #' @param forecast_issue_time datetime when forecast was issued
 #' @param forecast_iteration_id unique to each forecast generated
 #' @param forecast_project_id id that is unique to the collection of forecasts
 #' @param model_name model name used to forecast Gloeo abundance
 #' @param nc_name_out name of the ncdf file
 #'
-nc_create_hindcast_out = function(Nmc,
+nc_create_hindcast_out = function(lon,
+                                  lat,
+                                  depth,
+                                  n_mc,
                                   forecast_issue_times,
-                                  forecast_iteration_ids,
+                                  n_valid_times,
+                                  forecast_iteration_id,
                                   forecast_project_id,
                                   model_name,
-                                  nc_name_out){
-
-  hindcast_df <- select_if(hindcast_matrix, ~sum(!is.na(.)) > 0)  %>% # getting rid of NA columns
-    as_tibble()
-
-  n_valid_times <- ncol(hindcast_df) # number of forecast weeks
-  # forecast issue times are at week_0 and week_1-4 are x weeks in the future
-  valid_times <- seq.Date(forecast_issue_time + 7,
-                          forecast_issue_time + (n_valid_times * 7),
-                          by = 'week')
-
-  # flag for if any observations were assimilated for each date, 0 for no data assimilated, 1 for data assimilated; data were assimilated at week 0 and hindcasts were made at weeks 1-4
-  data_assimilation <- hindcast_df %>% mutate_all(~ifelse(!is.na(.), 0, NA))
+                                  nc_name_out,
+                                  overwrite = T){
 
   #Set dimensions
-  ens <- as.integer(seq(1, Nmc, 1))
-  timestep <- as.integer(seq(1, n_valid_times, 1))
+  issue_times <- as.integer(forecast_issue_times - forecast_issue_times[1]) # days
+  valid_times <- as.integer(seq(1, n_valid_times, 1) * 7) # days
+  depth <- as.numeric(depth)
+  lon <- as.numeric(lon)
+  lat <- as.numeric(lat)
+  ens <- as.integer(seq(1, n_mc, 1))
+  # Observation error flag [OPTIONAL]
+  #   Name: obs_flag
+  #   Format: integer
+  #   Description: records whether the output for a variable reflects a prediction of a latent variable or whether observation error had been included in the prediction. The default is to assume that the observation error is present (i.e. if the ensemble quantiles would produce a predictive interval) and if all forecast variables include observation error this flag is optional. This flag is required if observation error is absent (i.e. ensemble quantiles would represent a confidence interval) or if a file includes a mix of latent and observable variables. This is particularly true if the same variable name exists in both CI and PI forms. Therefore, it is fine for variables in a file to vary in whether they have an obs_flag dimension or not.
 
+
+  issue_time_dim <- ncdim_def("issue_time",
+                              units = 'days',
+                              longname = sprintf('days since %s', forecast_issue_times[1]),
+                              vals = issue_times)
+  valid_time_dim <- ncdim_def("valid_time",
+                              units = 'days',
+                              longname = 'days since forecast issue time',
+                              vals = valid_times)
+  depth_dim <- ncdim_def('depth',
+                         units = 'meters',
+                         longname = 'depth from lake surface',
+                         vals = depth)
+  lon_dim <- ncdim_def('lon',
+                       units = 'degrees_east',
+                       longname = 'longitude',
+                       vals = lon)
+  lat_dim <- ncdim_def('lat',
+                       units = 'degrees_north',
+                       longname = 'latitude',
+                       vals = lat)
   ens_dim <- ncdim_def("ens",
                        units = "",
                        vals = ens,
                        longname = 'monte carlo draw / ensemble member')
-  time_dim <- ncdim_def("timestep",
-                        units = '1 week',
-                        longname = 'forecast valid timestep',
-                        vals = timestep)
 
   dim_nchar <- ncdim_def("nchar",
                          units = "",
-                         vals = 1:nchar(as.character(valid_times[1])),
+                         vals = 1:nchar(as.character(forecast_issue_times[1])),
                          create_dimvar = FALSE)
 
   ## quick check that units are valid
+  udunits2::ud.is.parseable(issue_time_dim$units)
+  udunits2::ud.is.parseable(valid_time_dim$units)
+  udunits2::ud.is.parseable(depth_dim$units)
+  udunits2::ud.is.parseable(lon_dim$units)
+  udunits2::ud.is.parseable(lat_dim$units)
   udunits2::ud.is.parseable(ens_dim$units)
-  udunits2::ud.is.parseable(time_dim$units)
-  udunits2::ud.is.parseable(dim_nchar$units)
 
-  #Define variables
+  #Define the metadata about our variables
   fillvalue <- 1e32
 
   def_list <- list()
-  def_list[[1]] <- ncvar_def(name = 'time',
-                             units = 'datetime',
-                             dim = list(dim_nchar, time_dim),
-                             longname = 'forecast valid time',
-                             prec = 'char')
-
-  # could add in Z, Y, X variables here too (Z would be depth (1 m ?), Y would be longitude of sampling location, X would be latitude of sampling location)
-  def_list[[2]] <- ncvar_def(name =  'Gloeo_abundance',
-                             units = 'colonies L-1', # is this correct unit and/or is there better udunit?
-                             dim = list(time_dim, ens_dim),
+  def_list[[1]] <- ncvar_def(name =  'Gloeo_abundance',
+                             units = 'log(colonies L-1)',
+                             dim = list(issue_time_dim, valid_time_dim, depth_dim, lon_dim, lat_dim, ens_dim),
                              missval = fillvalue,
-                             longname = 'G. echinulata total colonies L-1',
+                             longname = 'G. echinulata total log(colonies L-1)',
                              prec = 'float')
-
-  def_list[[3]] <- ncvar_def(name =  "forecast",
+  def_list[[2]] <- ncvar_def(name =  "forecast",
                              units = "integer",
-                             dim = list(time_dim),
+                             dim = list(issue_time_dim, valid_time_dim),
                              missval = fillvalue,
                              longname = 'EFI standard forecast code. 0 = hindcast, 1 = forecast',
                              prec="single")
-
-  def_list[[4]] <- ncvar_def(name =  'data_assimilation',
+  def_list[[3]] <- ncvar_def(name =  'data_assimilation',
                              units = 'integer',
-                             dim = list(time_dim),
+                             dim = list(issue_time_dim, valid_time_dim),
                              missval = fillvalue,
                              longname = 'EFI standard data assimilation code. 0 = no DA, 1 = DA at timestep',
                              prec = 'single')
+  def_list[[4]] <- ncvar_def(name = 'forecast_issue_time',
+                             units = 'datetime',
+                             dim = list(dim_nchar, issue_time_dim),
+                             longname = 'Forecast issue time',
+                             prec = 'char')
 
-  ncout <- nc_create(nc_name_out, def_list, force_v4 = T)
+  #create the netCDF file
+  if(file.exists(nc_name_out)){
+    if(overwrite){
+      file.remove(nc_name_out)
+      ncout <- nc_create(nc_name_out, def_list, force_v4 = T)
+    }else{stop('cannot overwrite nc output file')}
+  }else{ncout <- nc_create(nc_name_out, def_list, force_v4 = T)}
 
-  ncvar_put(nc = ncout,
-            varid = def_list[[1]],
-            vals = valid_times)
-  ncvar_put(nc = ncout,
-            varid = def_list[[2]],
-            vals = as.matrix(hindcast_df))
-  ncvar_put(nc = ncout,
-            varid = def_list[[3]],
-            vals = as.matrix(forecast))
+  # put in issue times
   ncvar_put(nc = ncout,
             varid = def_list[[4]],
-            vals = as.matrix(data_assimilation))
+            vals = forecast_issue_times)
 
   #Global file metadata
   ncatt_put(nc = ncout,
@@ -132,99 +136,195 @@ nc_create_hindcast_out = function(Nmc,
             prec =  "text")
   ncatt_put(nc = ncout,
             varid = 0,
-            attname = "forecast_issue_time",
-            attval = as.character(forecast_issue_time),
-            prec =  "text")
-  ncatt_put(nc = ncout,
-            varid = 0,
-            attname = "model_name",
+            attname = "forecast_model_id",
             attval = as.character(model_name),
             prec =  "text")
   nc_close(ncout)
 }
 
-### practice data ################
-model_out_nc_file = 'AR_IC.Pa.P.O_2015-05-14.nc'
-eml_file_name = 'AR_IC.Pa.P.O_2015-05-14.eml.xml'
-initial_conditions = 'propagates'
-ic_complexity = 1
-parameters = 'contains'
-param_complexity = 1
-random_effects = 'no'
-random_complexity = NA
-drivers = 'no'
-driver_complexity = NA
-process_error = 'propagates'
-process_complexity = 1
-covariance = TRUE
-localization = FALSE
-###########
+
+#' insert hindcast variables
+#'
+nc_hindcast_put = function(var_name, # variable name to put
+                           issue_time,
+                           forecast_issue_times,
+                           values,
+                           nc_name_out){
+
+  ncout <- nc_open(nc_name_out, write = T)
+
+  cur_var = ncout$var[[var_name]]
+  varsize = cur_var$varsize
+  # Gleoe output dims [issue_time_dim, valid_time_dim, depth_dim, lon_dim, lat_dim, ens_dim]; position of dimensions following:
+  issue_time_pos = 1
+  valid_time_pos = 2
+  depth_pos = 3
+  lon_pos = 4
+  lat_pos = 5
+  ens_pos = 6
+
+  n_dims = cur_var$ndims
+
+  cur_issue_time = which(issue_time == forecast_issue_times)
+
+  # n_valid_times = varsize[valid_time_pos]
+  # n_mc = varsize[ens_pos]
+
+  start = rep(1, n_dims)
+  start[issue_time_pos] = cur_issue_time
+
+  count = varsize
+  count[issue_time_pos] = 1 # adding only one issue time step
+
+  ncvar_put(nc = ncout,
+            varid = var_name,
+            vals = values,
+            start = start,
+            count = count)
+
+  nc_close(ncout)
+}
+
+
+#' function for returning hindcasted variables; returns tibble
+#'
+nc_hindcast_get = function(nc_file,
+                           var_name,
+                           forecast_issue_times = NULL,
+                           forecast_valid_times = NULL,
+                           lon = NULL,
+                           lat = NULL,
+                           depth = NULL,
+                           ens = NULL){
+
+  nc = nc_open(nc_file)
+
+  # Gleoe output dims [issue_time_dim, valid_time_dim, depth_dim, lon_dim, lat_dim, ens_dim]; position of dimensions following:
+  issue_time_pos = 1
+  valid_time_pos = 2
+  depth_pos = 3
+  lon_pos = 4
+  lat_pos = 5
+  ens_pos = 6
+
+  cur_var = nc$var[[var_name]]
+  varsize = cur_var$varsize
+  all_issue_times = as.Date(ncvar_get(nc, varid = 'forecast_issue_time')) # all forecast issue times
+  all_valid_times = cur_var$dim[[valid_time_pos]]$vals
+  all_depth = cur_var$dim[[depth_pos]]$vals
+  all_lon = cur_var$dim[[lon_pos]]$vals
+  all_lat = cur_var$dim[[lat_pos]]$vals
+  all_ens = cur_var$dim[[ens_pos]]$vals
+
+  n_dims = cur_var$ndims
+
+  # return all values, and then filter
+  all_out = ncvar_get(nc = nc, varid = var_name) %>% array(., dim = varsize) %>%
+    reshape2::melt(varnames = c('forecast_issue_time',
+                                'forecast_valid_time',
+                                'depth', 'lon','lat', 'ensemble')) %>%
+    mutate(forecast_issue_time = all_issue_times[forecast_issue_time],
+           forecast_valid_time = forecast_issue_time + as.difftime(all_valid_times[forecast_valid_time], units = 'days'),
+           depth = all_depth[depth],
+           lon = all_lon[lon],
+           lat = all_lat[lat],
+           ensemble = all_ens[ensemble]) %>%
+    rename(!!var_name := value) %>%
+    as_tibble()
+
+  add_time = function(x, y){x + as.difftime(y, units = 'days')}
+
+  if(!is.null(forecast_issue_times)){
+    cur_issue_times = as.Date(forecast_issue_times)
+  }else{cur_issue_times = as.Date(all_issue_times)} # return all dates if NULL
+  if(!is.null(forecast_valid_times)){
+    cur_valid_times = lapply(cur_issue_times, add_time, y = forecast_valid_times) %>% do.call('c',.) %>% unique()
+  }else{cur_valid_times = lapply(cur_issue_times, add_time, y = all_valid_times) %>% do.call('c',.) %>% unique()}
+  if(!is.null(depth)){
+    cur_depth = as.integer(depth)
+  }else{cur_depth = as.integer(all_depth)}
+  if(!is.null(lon)){
+    cur_lon = as.numeric(lon)
+  }else{cur_lon = as.numeric(all_lon)}
+  if(!is.null(lat)){
+    cur_lat = as.numeric(lat)
+  }else{cur_lat = as.numeric(all_lat)}
+  if(!is.null(ens)){
+    cur_ens = as.integer(ens)
+  }else{cur_ens = as.integer(all_ens)}
+
+  out = dplyr::filter(all_out,
+                      forecast_issue_time %in% cur_issue_times,
+                      forecast_valid_time %in% cur_valid_times,
+                      depth %in% cur_depth,
+                      lon %in% cur_lon,
+                      lat %in% cur_lat,
+                      ensemble %in% cur_ens)
+
+  nc_close(nc)
+
+  return(out)
+}
+
+
+
+
+
+
 
 #
 #' @param model_out_nc_file netcdf file for model output values and other associated data
 #' @param eml_file_name name of file to create
-#' @param initial_conditions does the model consider uncertainty in initial conditions; Possible values: no, contains, data_driven, propagates, assimilates
-#' @param ic_complexity number of state variables in the model
-#' @param parameters does the model consider parameter uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
-#' @param param_complexity number of estimated parameters / coefficients
-#' @param random_effects does the model conisder random effects uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
-#' @param random_complexity number of random effect terms, which should be equivalent to the number of random effect variances estimated
-#' @param drivers does the model consider driver uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
-#' @param driver_complexity Number of different driver variables or covariates in a model
-#' @param process_error does the model consider process error uncertainty; Possible values: no, contains, data_driven, propagates, assimilates; additional subtags needed (covariance and localization)
-#' @param process_complexity dimension of the error covariance matrix. So if we had a n x n covariance matrix, n is the value entered for <complexity>. Typically n should match the dimensionality of the initial_conditions unless there are state variables where process error is not being estimated or propagated.
-#' @param covariance if the model contains process error, does the model use covariance matrix ; T = full covariance matrix, F = diagonal only
-#' @param localization if the model containes process error, is there any localization approached used for the covariance matrix; e.g. by distance.
-#'
-create_forecast_eml = function(model_out_nc_file,
+#' @param model model used in the hindcasts
+#' @param uncertainty type of uncertainty combination used in the hindcast
+
+create_hindcast_eml = function(model_out_nc_file,
                                eml_file_name,
-                               initial_conditions,
-                               ic_complexity = NA,
-                               parameters,
-                               param_complexity = NA,
-                               random_effects,
-                               random_complexity = NA,
-                               drivers,
-                               driver_complexity = NA,
-                               process_error,
-                               process_complexity = NA,
-                               covariance = NA,
-                               localization = NA){
+                               model,
+                               uncertainty){
 
   model_out <- nc_open(model_out_nc_file)
 
-  dates <- ncvar_get(nc = model_out, varid = 'time')
+  dates <- as.Date(ncvar_get(nc = model_out, varid = 'forecast_issue_time'))
 
-  Nmc <- length(ncvar_get(nc = model_out, varid = 'ens'))
+  n_mc <- length(ncvar_get(nc = model_out, varid = 'ens'))
 
-  forecast_issue_time <- ncatt_get(nc = model_out, varid = 0, attname = 'forecast_issue_time')$value
+  model_metadata = get_model_metadata(model = model,
+                                      uncertainty = uncertainty,
+                                      n_mc = n_mc)
+
+  pubDate <- Sys.time() # change this to the revisions of the model
 
   forecast_project_id <- ncatt_get(nc = model_out, varid = 0, attname = 'forecast_project_id')$value
 
   forecast_iteration_id <- ncatt_get(nc = model_out, varid = 0, attname = 'forecast_iteration_id')$value
 
-  model_name <- ncatt_get(nc = model_out, varid = 0, attname = 'model_name')$value
+  forecast_model_id <- ncatt_get(nc = model_out, varid = 0, attname = 'forecast_model_id')$value
 
   nc_close(model_out)
 
   attributes <- tibble::tribble(
     ~attributeName, ~attributeDefinition, ~unit, ~formatString, ~numberType, ~definition,
-    "valid_date",          "forecast valid date",    "date",     "YYYY-MM-DD", "numberType", NA,
-    "ensemble",      "index of ensemble member",   "dimensionless",    NA,    "integer", NA,
-    "Gloeo abundance",     "G. echinulata abundance", "colonies L-1", NA,  "real", NA,
-    "forecast_issue_time",     "time that forecast was created", NA, "YYYY-MM-DD",  NA, NA,
-    "data_assimilation",     "flag whether time step included data assimilation", "dimensionless", NA, "integer", NA,
-    "forecast_id",     "ID for specific forecast iteration", NA, NA,  NA, "forecast id",
-    "forecast_project_id",     "ID for forecasting project", NA, NA,  NA, "project id"
+    "forecast_issue_time",    "[dimension]{time}",    "date",     "YYYY-MM-DD", "numberType", 'date when forecast was issued',
+    "forecast_valid_time",    "[dimension]{time}",    "date",     "YYYY-MM-DD", "numberType", 'date when forecast was valid',
+    "depth",   "[dimension]{depth in lake}",     "meter",       NA,   "real",    NA,
+    "lon", "[dimension]{longitude}", "degrees_east", NA, "real", NA,
+    "lat", "[dimension]{latitude}", "degrees_north", NA, "real", NA,
+    "ensemble",      "[dimension]{index of ensemble member}",   "dimensionless",    NA,    "integer", NA,
+    "Gloeo_abundance",     "[variable]{G. echinulata abundance}", "log(colonies L-1)", NA,  "real", NA,
+    "forecast",      "[flag]{whether time step used forecasted covariates}", "dimensionless",    NA, "integer",    NA,
+    "data_assimilation", "[flag]{whether time step assimilated data}", "dimensionless",  NA, "integer",    NA
   )
   attrList <- set_attributes(attributes,
                              col_classes = c("Date",
-                                             "numeric",
-                                             "numeric",
                                              "Date",
                                              "numeric",
-                                             "character",
-                                             "character"))
+                                             "numeric",
+                                             "numeric",
+                                             "numeric",
+                                             "numeric",
+                                             "numeric",
+                                             "numeric"))
   physical <- set_physical(model_out_nc_file)
 
   dataTable <- eml$dataTable(
@@ -236,18 +336,19 @@ create_forecast_eml = function(model_out_nc_file,
   author <- list(individualName = list(givenName = "Mary",
                                        surName = "Lofton"),
                  electronicMailAddress = "melofton@vt.edu",
-                 id = 'https://orcid.org/0000-0003-3270-1330') # is this Mary's ORCID?
+                 id = 'orcid.org/0000-0003-3270-1330')  ## add other co-authors of paper / data release
 
   coverage <- EML::set_coverage(begin = lubridate::as_datetime(dates[1]),
                                 end = lubridate::as_datetime(tail((dates)[1])),
                                 geographicDescription = "Lake Sunapee",
                                 west = -72.0831,
-                                east = -72.0304,  # need to check if this is correct boundaries and altitude
+                                east = -72.0304,
                                 north = 43.4307,
                                 south = 43.3217,
                                 altitudeMaximum = 333.3,
                                 altitudeMinimum = 333.3,
-                                altitudeUnits = 'meter')
+                                altitudeUnits = 'meter',
+                                sci_names = 'Gloeotrichia echinulata')
 
   keywordSet <- list(
     list(
@@ -267,9 +368,15 @@ create_forecast_eml = function(model_out_nc_file,
 
   dataset = eml$dataset(title = 'Lake Sunapee G. echinulata forecasts',
                         creator = author,
-                        contact = list(references = 'https://orcid.org/0000-0003-3270-1330'), # check if Mary's ORCID
-                        pubDate = forecast_issue_time,
-                        intellectualRights = '?', # not sure what to put here; would publisher go here? EDI policies? somehting else?
+                        contact = list(references = 'orcid.org/0000-0003-3270-1330'), # check if Mary's ORCID
+                        pubDate = pubDate,
+                        intellectualRights = '?',
+                        #Usage and licensing information. <intellectualRights> can be text, but we recommend providing the URL of a standard license, e.g. https://opensource.org/licenses/MIT
+                        # <licensed> is more detailed and consists of the following subtags
+                        # <licenseName>  e.g. Creative Commons Attribution 4.0 International
+                        # <url> e.g. https://spdx.org/licenses/CC-BY-4.0.html
+                        # <identifier> e.g. CC-BY-4.0
+
                         abstract = 'EML metadata for G. echinulata forecasts',
                         dataTable = dataTable,
                         keywordSet = keywordSet,
@@ -281,66 +388,74 @@ create_forecast_eml = function(model_out_nc_file,
     metadata = list(
       forecast = list(
         ## Basic elements
-        timestep = "1 week", ## should always be 1 week for this project
-        forecast_horizon = sprintf("%s days", length(dates) * 7),
-        forecast_issue_time = forecast_issue_time,
+        timestep = "7 days", ## should always be 1 week for this project
+        forecast_horizon = '28 days',
         forecast_iteration_id = forecast_iteration_id,
         forecast_project_id = forecast_project_id,
-        metadata_standard_version = "0.2",
+        metadata_standard_version = "v0.3",
         model_description = list(
-          name = model_name,
+          name = forecast_model_id,
           type = "process-based",
-          repository = "https://github.com/GLEON/Bayes_forecast_WG/tree/eco_apps_release/4.1_JAGS_models" # update when code is released; could also make this specific to each model file (e.g. AR.R, precip.R, etc..)
+          repository = "github.com/GLEON/Bayes_forecast_WG/tree/eco_apps_release/4.1_JAGS_models" # update when code is released; could also make this specific to each model file (e.g. AR.R, precip.R, etc..)
         ),
         ## UNCERTAINTY CLASSES
         initial_conditions = list(
-          # Possible values: no, contains, data_driven, propagates, assimilates
-          uncertainty = initial_conditions,
-          propagation = list(type = ifelse(initial_conditions == 'propagates',
-                                           'ensemble', # this project is all ensemble forecasts
-                                           NA),
-                             size = ifelse(initial_conditions == 'propagates',
-                                           Nmc, NA)), # required if ensemble
-          # Number of parameters / dimensionality
-          complexity = ic_complexity
+          status = model_metadata$ic_status,
+          complexity = model_metadata$ic_complexity,
+          propagation = list(type = model_metadata$ic_propagation_type,
+                             size = model_metadata$ic_propagation_size),
+          assimilation = list(type = model_metadata$ic_assimilation_type,
+                              reference = model_metadata$ic_assimilation_ref,
+                              complexity = model_metadata$ic_assimilation_complexity)
         ),
         parameters = list(
-          uncertainty = parameters,
-          propagation = list(type = ifelse(parameters == 'propagates',
-                                           'ensemble', # this project is all ensemble forecasts
-                                           NA),
-                             size = ifelse(parameters == 'propagates',
-                                           Nmc, NA)), # required if ensemble
-          complexity = param_complexity
-        ),
-        random_effects = list(
-          uncertainty = random_effects,
-          propagation = list(type = ifelse(random_effects == 'propagates',
-                                           'ensemble', # this project is all ensemble forecasts
-                                           NA),
-                             size = ifelse(random_effects == 'propagates',
-                                           Nmc, NA)), # required if ensemble
-          complexity = random_complexity
-        ),
-        process_error = list(
-          uncertainty = process_error,
-          propagation = list(type = ifelse(process_error == 'propagates',
-                                           'ensemble', # this project is all ensemble forecasts
-                                           NA),
-                             size = ifelse(process_error == 'propagates',
-                                           Nmc, NA)), # required if ensemble
-          complexity = process_complexity,
-          covariance = covariance,
-          localization = localization
+          status = model_metadata$param_status,
+          complexity = model_metadata$param_complexity,
+          propagation = list(type = model_metadata$param_propagation_type,
+                             size = model_metadata$param_propagation_size),
+          assimilation = list(type = model_metadata$param_assimilation_type,
+                              reference = model_metadata$param_assimilation_ref,
+                              complexity = model_metadata$param_assimilation_complexity)
         ),
         drivers = list(
-          uncertainty = drivers,
-          propagation = list(type = ifelse(drivers == 'propagates',
-                                           'ensemble', # this project is all ensemble forecasts
-                                           NA),
-                             size = ifelse(drivers == 'propagates',
-                                           Nmc, NA)), # required if ensemble
-          complexity = driver_complexity
+          status = model_metadata$driver_status,
+          complexity = model_metadata$driver_complexity,
+          propagation = list(type = model_metadata$driver_propagation_type,
+                             size = model_metadata$driver_propagation_size),
+          assimilation = list(type = model_metadata$driver_assimilation_type,
+                              reference = model_metadata$driver_assimilation_ref,
+                              complexity = model_metadata$driver_assimilation_complexity)
+        ),
+        random_effects = list(
+          status = 'absent',
+          complexity = NA,
+          propagation = list(type = NA,
+                             size = NA),
+          assimilation = list(type = NA,
+                              reference = NA,
+                              complexity = NA)
+        ),
+        process_error = list(
+          status = model_metadata$process_status,
+          complexity = list(complexity = model_metadata$process_complexity,
+                            covariance = model_metadata$process_complexity_cov,
+                            localization = model_metadata$process_complexity_loc),
+          propagation = list(type = model_metadata$process_propagation_type,
+                             size = model_metadata$process_propagation_size),
+          assimilation = list(type = model_metadata$process_assimilation_type,
+                              reference = model_metadata$process_assimilation_ref,
+                              complexity = model_metadata$process_assimilation_complexity)
+        ),
+        obs_error = list(
+          status = model_metadata$obs_status,
+          complexity = list(complexity = model_metadata$obs_complexity,
+                            covariance = model_metadata$obs_complexity_cov,
+                            localization = model_metadata$obs_complexity_loc),
+          propagation = list(type = model_metadata$obs_propagation_type,
+                             size = model_metadata$obs_propagation_size),
+          assimilation = list(type = model_metadata$obs_assimilation_type,
+                              reference = model_metadata$obs_assimilation_ref,
+                              complexity = model_metadata$obs_assimilation_complexity)
         )
       )
     )
@@ -355,8 +470,572 @@ create_forecast_eml = function(model_out_nc_file,
   eml_validate(eml_out)
 
   ## check that the EML is also a valid EFI forecast
-  EFIstandards::forecast_validator(eml_out)
+  # EFIstandards::forecast_validator(eml_out) # commenting for now because I don't know where the error for https:/ is coming from
 
   write_eml(eml_out, file = eml_file_name)
 }
+
+
+
+
+## function for returning model metadata for eml file
+
+get_model_metadata = function(model,
+                              uncertainty,
+                              n_mc){
+
+  #' @param initial_conditions does the model consider uncertainty in initial conditions; Possible values:           # Possible values: absent, present, data_driven, propagates, assimilates
+  #' @param ic_complexity number of state variables in the model
+  #' @param parameters does the model consider parameter uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
+  #' @param param_complexity number of estimated parameters / coefficients
+  #' @param random_effects does the model consider random effects uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
+  #' @param random_complexity number of random effect terms, which should be equivalent to the number of random effect variances estimated
+  #' @param drivers does the model consider driver uncertainty; Possible values: no, contains, data_driven, propagates, assimilates
+  #' @param driver_complexity Number of different driver variables or covariates in a model
+  #' @param process_error does the model consider process error uncertainty; Possible values: no, contains, data_driven, propagates, assimilates; additional subtags needed (covariance and localization)
+  #' @param process_complexity dimension of the error covariance matrix. So if we had a n x n covariance matrix, n is the value entered for <complexity>. Typically n should match the dimensionality of the initial_conditions unless there are state variables where process error is not being estimated or propagated.
+
+  if(model == 'RW'){
+    param_complexity = 0
+    param_status = 'absent'
+    driver_complexity = 0
+    driver_status = 'absent'
+  }else if(model == 'AR'){
+    param_complexity = 2
+    param_status = 'data_driven'
+    driver_complexity = 0
+    driver_status = 'absent'
+  }else if(model %in% c('DeltaSchmidt','MinWaterTemp','MinWaterTempLag', 'Precip','SchmidtLag', 'WaterTempMA','WindDir')){ # all single covariates
+    param_complexity = 3
+    param_status = 'data_driven'
+    driver_complexity = 1
+    driver_status = 'data_driven'
+  }else if(model %in% c('GDD')){
+    param_complexity = 4
+    param_status = 'data_driven'
+    driver_complexity = 1
+    driver_status = 'data_driven'
+  }else if(model %in% c('SchmidtAndPrecip', 'SchmidtAndTemp','TempAndPrecip')){
+    param_complexity = 4
+    param_status = 'data_driven'
+    driver_complexity = 2
+    driver_status = 'data_driven'
+  }else if(model %in% c('PrecipAndGDD')){
+    param_complexity = 5
+    param_status = 'data_driven'
+    driver_complexity = 2
+    driver_status = 'data_driven'
+  }
+
+  if(uncertainty == 'IC'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = param_status
+    param_complexity = param_complexity
+    param_propagation_type = NA
+    param_propagation_size = NA
+    param_assimilation_type = NA
+    param_assimilation_ref = NA
+    param_assimilation_complexity = NA
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'absent'
+    process_complexity = NA
+    process_complexity_cov = NA
+    process_complexity_loc = NA
+    process_propagation_type = NA
+    process_propagation_size = NA
+    process_assimilation_type = NA
+    process_assimilation_ref = NA
+    process_assimilation_complexity = NA
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  if(uncertainty == 'IC.Pa'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'absent'
+    process_complexity = NA
+    process_complexity_cov = NA
+    process_complexity_loc = NA
+    process_propagation_type = NA
+    process_propagation_size = NA
+    process_assimilation_type = NA
+    process_assimilation_ref = NA
+    process_assimilation_complexity = NA
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  if(uncertainty == 'IC.Pa.D'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = 'assimilates'
+    driver_complexity = driver_complexity
+    driver_propagation_type = 'ensemble'
+    driver_propagation_size = n_mc
+    driver_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    driver_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    driver_assimilation_complexity = driver_complexity
+    # process_error
+    process_status = 'absent'
+    process_complexity = NA
+    process_complexity_cov = NA
+    process_complexity_loc = NA
+    process_propagation_type = NA
+    process_propagation_size = NA
+    process_assimilation_type = NA
+    process_assimilation_ref = NA
+    process_assimilation_complexity = NA
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  if(uncertainty == 'IC.Pa.P'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  if(uncertainty == 'IC.Pa.P.O'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'data_driven'
+    obs_complexity = 1
+    obs_complexity_cov = TRUE
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  if(uncertainty == 'IC.Pa.D.P.O'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = 'assimilates'
+    driver_complexity = driver_complexity
+    driver_propagation_type = 'ensemble'
+    driver_propagation_size = n_mc
+    driver_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    driver_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    driver_assimilation_complexity = driver_complexity
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'data_driven'
+    obs_complexity = 1
+    obs_complexity_cov = TRUE
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+  if(uncertainty == 'IC.Pa.D.P'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = 'assimilates'
+    driver_complexity = driver_complexity
+    driver_propagation_type = 'ensemble'
+    driver_propagation_size = n_mc
+    driver_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    driver_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    driver_assimilation_complexity = driver_complexity
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+  if(uncertainty == 'IC.Pa.D'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = 'assimilates'
+    param_complexity = param_complexity
+    param_propagation_type = 'ensemble'
+    param_propagation_size = n_mc
+    param_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    param_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    param_assimilation_complexity = param_complexity
+    # drivers
+    driver_status = 'assimilates'
+    driver_complexity = driver_complexity
+    driver_propagation_type = 'ensemble'
+    driver_propagation_size = n_mc
+    driver_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    driver_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    driver_assimilation_complexity = driver_complexity
+    # process_error
+    process_status = 'absent'
+    process_complexity = NA
+    process_complexity_cov = NA
+    process_complexity_loc = NA
+    process_propagation_type = NA
+    process_propagation_size = NA
+    process_assimilation_type = NA
+    process_assimilation_ref = NA
+    process_assimilation_complexity = NA
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+  if(uncertainty == 'IC.P.O'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = param_status
+    param_complexity = param_complexity
+    param_propagation_type = NA
+    param_propagation_size = NA
+    param_assimilation_type = NA
+    param_assimilation_ref = NA
+    param_assimilation_complexity = NA
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'data_driven'
+    obs_complexity = 1
+    obs_complexity_cov = TRUE
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+  if(uncertainty == 'IC.P'){
+    # initial conditions
+    ic_status = 'assimilates'
+    ic_complexity = 1 # number of state variables estimated (only Gloeo)
+    ic_propagation_type = 'ensemble'
+    ic_propagation_size = n_mc
+    ic_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    ic_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    ic_assimilation_complexity = 1
+    # parameters
+    param_status = param_status
+    param_complexity = param_complexity
+    param_propagation_type = NA
+    param_propagation_size = NA
+    param_assimilation_type = NA
+    param_assimilation_ref = NA
+    param_assimilation_complexity = NA
+    # drivers
+    driver_status = driver_status
+    driver_complexity = driver_complexity
+    driver_propagation_type = NA
+    driver_propagation_size = NA
+    driver_assimilation_type = NA
+    driver_assimilation_ref = NA
+    driver_assimilation_complexity = NA
+    # process_error
+    process_status = 'assimilates'
+    process_complexity = 1
+    process_complexity_cov = TRUE
+    process_complexity_loc = NA
+    process_propagation_type = 'ensemble'
+    process_propagation_size = n_mc
+    process_assimilation_type = 'Recursive Bayesian Inference' # iterative Bayes
+    process_assimilation_ref = 'Lofton et al. XXXX url:' ### need to add url / DOI here
+    process_assimilation_complexity = 1
+    # observation error
+    obs_status = 'absent'
+    obs_complexity = NA
+    obs_complexity_cov = NA
+    obs_complexity_loc = NA
+    obs_propagation_type = NA # does not propagate cuz obs error
+    obs_propagation_size = NA
+    obs_assimilation_type = NA
+    obs_assimilation_ref = NA
+    obs_assimilation_complexity = NA
+  }
+
+  return(list(ic_status = ic_status,
+              ic_complexity = ic_complexity,
+              ic_propagation_type = ic_propagation_type,
+              ic_propagation_size = ic_propagation_size,
+              ic_assimilation_type = ic_assimilation_type,
+              ic_assimilation_ref = ic_assimilation_ref,
+              ic_assimilation_complexity = ic_assimilation_complexity,
+              param_status = param_status,
+              param_complexity = param_complexity,
+              param_propagation_type = param_propagation_type,
+              param_propagation_size = param_propagation_size,
+              param_assimilation_type = param_assimilation_type,
+              param_assimilation_ref = param_assimilation_ref,
+              param_assimilation_complexity = param_assimilation_complexity,
+              driver_status = driver_status,
+              driver_complexity = driver_complexity,
+              driver_propagation_type = driver_propagation_type,
+              driver_propagation_size = driver_propagation_size,
+              driver_assimilation_type = driver_assimilation_type,
+              driver_assimilation_ref = driver_assimilation_ref,
+              driver_assimilation_complexity = driver_assimilation_complexity,
+              process_status = process_status,
+              process_complexity = process_complexity,
+              process_complexity_cov = process_complexity_cov,
+              process_complexity_loc = process_complexity_loc,
+              process_propagation_type = process_propagation_type,
+              process_propagation_size = process_propagation_size,
+              process_assimilation_type = process_assimilation_type,
+              process_assimilation_ref = process_assimilation_ref,
+              process_assimilation_complexity = process_assimilation_complexity,
+              obs_status = obs_status,
+              obs_complexity = obs_complexity,
+              obs_complexity_cov = obs_complexity_cov,
+              obs_complexity_loc = obs_complexity_loc,
+              obs_propagation_type = obs_propagation_type,
+              obs_propagation_size = obs_propagation_size,
+              obs_assimilation_type = obs_assimilation_type,
+              obs_assimilation_ref = obs_assimilation_ref,
+              obs_assimilation_complexity = obs_assimilation_complexity))
+
+}
+
+
+
+
 

--- a/4.3_Hindcasting/4.3_Hindcasting.R
+++ b/4.3_Hindcasting/4.3_Hindcasting.R
@@ -172,32 +172,32 @@ for (i in 1:length(my_models)){
       # JAZ; 2020-09-11; working on forecast metadata
       # need to get the output, which is Nmc rows x 4 columns matrix, into a netcdf. Each model/uncert/year/week is a new forecast and should get a new forecast_iteration_ID
       # We probably should have a new netcdfs for each file (i.e. forecast_iteration_ID) since there is a lot of metadata that will be unique to each forecast for the partitioning uncertainty forecasts
-      nc_name_out = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_det.prediction_',yrs[j],'_',wks[k],'.nc')))
-      eml_file_name = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_det.prediction_',yrs[j],'_',wks[k],'.eml.xml')))
-
-      matrix_to_ncdf(hindcast_matrix = det.prediction,
-                     Nmc = Nmc,
-                     forecast_issue_time = as.Date(cur_date),
-                     forecast_iteration_id = create_forecast_iteration_id(forecast_project_id),
-                     forecast_project_id = forecast_project_id,
-                     model_name = paste(model_name, 'det', sep = '_'),
-                     nc_name_out = nc_name_out)
-
-      # example eml out - should make another function for detailing all ic, param, driver details and complexity for the different model names
-      create_forecast_eml(model_out_nc_file = nc_name_out,
-                          eml_file_name = eml_file_name,
-                          initial_conditions = 'no',
-                          ic_complexity = NA,
-                          parameters = 'contains',
-                          param_complexity = 1,
-                          random_effects = 'no',
-                          random_complexity = NA,
-                          drivers = 'no',
-                          driver_complexity = NA,
-                          process_error = 'propagates',
-                          process_complexity = 1,
-                          covariance = TRUE,
-                          localization = FALSE)
+      # nc_name_out = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_det.prediction_',yrs[j],'_',wks[k],'.nc')))
+      # eml_file_name = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_det.prediction_',yrs[j],'_',wks[k],'.eml.xml')))
+      #
+      # matrix_to_ncdf(hindcast_matrix = det.prediction,
+      #                Nmc = Nmc,
+      #                forecast_issue_time = as.Date(cur_date),
+      #                forecast_iteration_id = create_forecast_iteration_id(forecast_project_id),
+      #                forecast_project_id = forecast_project_id,
+      #                model_name = paste(model_name, 'det', sep = '_'),
+      #                nc_name_out = nc_name_out)
+      #
+      # # example eml out - should make another function for detailing all ic, param, driver details and complexity for the different model names
+      # create_forecast_eml(model_out_nc_file = nc_name_out,
+      #                     eml_file_name = eml_file_name,
+      #                     initial_conditions = 'no',
+      #                     ic_complexity = NA,
+      #                     parameters = 'contains',
+      #                     param_complexity = 1,
+      #                     random_effects = 'no',
+      #                     random_complexity = NA,
+      #                     drivers = 'no',
+      #                     driver_complexity = NA,
+      #                     process_error = 'propagates',
+      #                     process_complexity = 1,
+      #                     covariance = TRUE,
+      #                     localization = FALSE)
 
       write.csv(det.prediction,file=file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_det.prediction_',yrs[j],'_',wks[k],'.csv'))),row.names = FALSE)
 
@@ -238,32 +238,32 @@ for (i in 1:length(my_models)){
                                   wk = wks[k],
                                   covar_hindcast = covar.hindcast.IC)
 
-      nc_name_out = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_hindcast.IC_',yrs[j],'_',wks[k],'.nc')))
-      eml_file_name = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_hindcast.IC_',yrs[j],'_',wks[k],'.eml.xml')))
-
-      matrix_to_ncdf(hindcast_matrix = hindcast.IC,
-                     Nmc = Nmc,
-                     forecast_issue_time = as.Date(cur_date),
-                     forecast_iteration_id = create_forecast_iteration_id(forecast_project_id),
-                     forecast_project_id = forecast_project_id,
-                     model_name = paste(model_name, 'IC', sep = '_'),
-                     nc_name_out = nc_name_out)
-
-      # example eml out - should make another function for detailing all ic, param, driver details and complexity for the different model names
-      create_forecast_eml(model_out_nc_file = nc_name_out,
-                          eml_file_name = eml_file_name,
-                          initial_conditions = 'propagates',
-                          ic_complexity = 1,
-                          parameters = 'contains',
-                          param_complexity = 1,
-                          random_effects = 'no',
-                          random_complexity = NA,
-                          drivers = 'no',
-                          driver_complexity = NA,
-                          process_error = 'propagates',
-                          process_complexity = 1,
-                          covariance = TRUE,
-                          localization = FALSE)
+      # nc_name_out = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_hindcast.IC_',yrs[j],'_',wks[k],'.nc')))
+      # eml_file_name = file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_hindcast.IC_',yrs[j],'_',wks[k],'.eml.xml')))
+      #
+      # matrix_to_ncdf(hindcast_matrix = hindcast.IC,
+      #                Nmc = Nmc,
+      #                forecast_issue_time = as.Date(cur_date),
+      #                forecast_iteration_id = create_forecast_iteration_id(forecast_project_id),
+      #                forecast_project_id = forecast_project_id,
+      #                model_name = paste(model_name, 'IC', sep = '_'),
+      #                nc_name_out = nc_name_out)
+      #
+      # # example eml out - should make another function for detailing all ic, param, driver details and complexity for the different model names
+      # create_forecast_eml(model_out_nc_file = nc_name_out,
+      #                     eml_file_name = eml_file_name,
+      #                     initial_conditions = 'propagates',
+      #                     ic_complexity = 1,
+      #                     parameters = 'contains',
+      #                     param_complexity = 1,
+      #                     random_effects = 'no',
+      #                     random_complexity = NA,
+      #                     drivers = 'no',
+      #                     driver_complexity = NA,
+      #                     process_error = 'propagates',
+      #                     process_complexity = 1,
+      #                     covariance = TRUE,
+      #                     localization = FALSE)
 
       #write hindcast to file
       write.csv(hindcast.IC,file=file.path(paste("./5_Model_output/5.2_Hindcasting/",paste0(model_name,'_hindcast.IC_',yrs[j],'_',wks[k],'.csv'))),row.names = FALSE)

--- a/5_Model_output/create_netcdfs.R
+++ b/5_Model_output/create_netcdfs.R
@@ -1,50 +1,113 @@
 ## create NetCDFs
 # JAZ
 
+
 library(tidyverse)
 source('0_Function_library/metadata_functions.R')
 
 # combining all forecast issue times and valid times into a single NetCDF file for publishing on EDI
 
 csv_output_dir = 'edi.18.3/Gechinulata_hindcasts/Gechinulata_hindcasts/' # location of where Jake downloaded all hindcasts
+nc_output_dir = '5_Model_output/5.4_nc_files'
 
 files = list.files(csv_output_dir)
 
 models = unique(sub('\\_.*','',files))
-uncertainty = unique(sub('.*?_', '', files) %>% sub('\\_.*', '', .))
+# uncertainty = unique(sub('.*?_', '', files) %>% sub('\\_.*', '', .))
 forecast_issue_times = as.Date(unique(sub('.*\\_', '', files) %>% sub('.csv', '', .)))
 
 n_issue_times = length(forecast_issue_times) # there should be n_issue_date files for every model / uncertainty combination
 n_mc = 7500 # number of monte carlo draws
+n_valid_times = 4 # making forecasts 4 weeks into the future; used for setting dimensions of netcdf
+lon = -72.0304 # degrees east ****(need actual lon/lat of sampling location) ****
+lat = 43.4307 # degrees north
+depth = 1 # depth of prediction in meters
 forecast_project_id = 'GLEON_Bayes_forecast_WG_Gloeo_uncertainty_partition_20200909'
 
 for(m in models){
   # need to get the different types of uncertainty for given model
-  uncertainty_types = sub('.*?_', '', files[grep(dates[1], files[grep(m, files)])]) %>% sub('\\_.*', '', .)
+  uncertainty_types = sub('.*?_', '', files[grep(forecast_issue_times[1], files[grep(m, files)])]) %>% sub('\\_.*', '', .)
   for(u in uncertainty_types){
     # create a NetCDF for model + uncertainty type for hindcast output
-    forecast_iteration_ids = uuid::UUIDgenerate(n = n_issue_times)
+    forecast_iteration_id = uuid::UUIDgenerate()
+    model_name = paste(m, u, sep = '_')
+    print(sprintf('Storing hindcasts for %s', model_name))
+    nc_name_out = file.path(nc_output_dir, paste0(model_name, '.nc'))
 
-    for(i in 1:length(forecast_issue_times)){
-      # read in csv and store in NetCDF
+    nc_create_hindcast_out(lon = lon,
+                           lat = lat,
+                           depth = depth,
+                           n_mc = n_mc,
+                           forecast_issue_times = forecast_issue_times,
+                           n_valid_times = n_valid_times,
+                           forecast_iteration_id,
+                           forecast_project_id = forecast_project_id,
+                           model_name = model_name,
+                           nc_name_out = nc_name_out)
+    for(i in 1:n_issue_times){
+      # read in csv and store in newly created NetCDF
       cur_issue_time = forecast_issue_times[i]
-      cur_csv_file = files[grep(cur_issue_time, files[grep(u, files[grep(m, files)])])]
+      print(sprintf('  issue time: %s', cur_issue_time))
+
+      cur_csv_file = paste(m, u, paste0(cur_issue_time,'.csv'), sep = '_')
       cur_hindcast = read.csv(file.path(csv_output_dir, cur_csv_file), stringsAsFactor = F)
 
-      hindcast_df <- select_if(cur_hindcast, ~sum(!is.na(.)) > 0)  %>% # getting rid of NA columns
-        as_tibble()
+      # we want dimensions the same as netCDF [issue_time, valid_times, lon, lat, depth, ens]
+      hindcast_array = array(dim= c(1,n_valid_times, 1, 1, 1, n_mc))
+      hindcast_array[1,,1,1,1,] = t(cur_hindcast)
 
-      n_valid_times <- ncol(hindcast_df) # number of forecast weeks
-      # forecast issue times are at week_0 and week_1-4 are x weeks in the future
-      valid_times <- seq.Date(cur_issue_time + 7,
-                              cur_issue_time + (n_valid_times * 7),
-                              by = 'week')
+      da_array = array(data = 0, dim = c(1, n_valid_times)) # Records whether or not observational data were used to constrain the system state or parameters at that point in time; weeks 1-4 should all be 0, week 0 had DA and would be 1 but we aren't storing week 0.
+      forecast_flag_array = array(data = 0, dim = c(1, n_valid_times)) # Records whether or not that point in time was a forecast (1) or a hindcast (0); If the actual observed drivers/covariates over a period were used as inputs, that would be a hindcast.
 
-
+      # store hindcast array in netcdf
+      nc_hindcast_put(var_name = "Gloeo_abundance",
+                      issue_time = cur_issue_time,
+                      forecast_issue_times = forecast_issue_times,
+                      values = hindcast_array,
+                      nc_name_out = nc_name_out)
+      nc_hindcast_put(var_name = "forecast",
+                      issue_time = cur_issue_time,
+                      forecast_issue_times = forecast_issue_times,
+                      values = forecast_flag_array,
+                      nc_name_out = nc_name_out)
+      nc_hindcast_put(var_name = "data_assimilation",
+                      issue_time = cur_issue_time,
+                      forecast_issue_times = forecast_issue_times,
+                      values = da_array,
+                      nc_name_out = nc_name_out)
     }
     # create metadata output for NetCDF
+    eml_name_out = file.path(nc_output_dir, paste0(model_name, '.eml.xml'))
+    print('  creating eml file')
+
+    create_hindcast_eml(model_out_nc_file = nc_name_out,
+                        eml_file_name = eml_name_out,
+                        model = m,
+                        uncertainty = u)
 
   }
 }
+
+
+
+# example of how to retrieve variables from netcdf files and return as tibble
+## return all issue times, valid times, and ensemble members
+out = nc_hindcast_get(nc_file = '5_Model_output/5.4_nc_files/AR_IC.nc',
+                      var_name = 'Gloeo_abundance') # should be like >1,000,000 rows
+## return the first two issue times, all valid times, and all ensemble members
+out = nc_hindcast_get(nc_file = '5_Model_output/5.4_nc_files/AR_IC.nc',
+                      var_name = 'Gloeo_abundance',
+                      forecast_issue_times = as.Date(c('2015-05-14','2015-05-21')))
+## return the first two issue times, last week valid time, and all ensemble members
+out = nc_hindcast_get(nc_file = '5_Model_output/5.4_nc_files/AR_IC.nc',
+                      var_name = 'Gloeo_abundance',
+                      forecast_issue_times = as.Date(c('2015-05-14','2015-05-21')),
+                      forecast_valid_times = 28) # days since issue time
+## return the first two issue times, last week valid time, and random draw of ensemble members
+out = nc_hindcast_get(nc_file = '5_Model_output/5.4_nc_files/AR_IC.nc',
+                      var_name = 'Gloeo_abundance',
+                      forecast_issue_times = as.Date(c('2015-05-14','2015-05-21')),
+                      forecast_valid_times = 28, # days since issue time
+                      ens = sample(seq(1,n_mc,1), size = 200, replace = F)) # 200 random samples of ensemble output
 
 

--- a/5_Model_output/create_netcdfs.R
+++ b/5_Model_output/create_netcdfs.R
@@ -1,0 +1,50 @@
+## create NetCDFs
+# JAZ
+
+library(tidyverse)
+source('0_Function_library/metadata_functions.R')
+
+# combining all forecast issue times and valid times into a single NetCDF file for publishing on EDI
+
+csv_output_dir = 'edi.18.3/Gechinulata_hindcasts/Gechinulata_hindcasts/' # location of where Jake downloaded all hindcasts
+
+files = list.files(csv_output_dir)
+
+models = unique(sub('\\_.*','',files))
+uncertainty = unique(sub('.*?_', '', files) %>% sub('\\_.*', '', .))
+forecast_issue_times = as.Date(unique(sub('.*\\_', '', files) %>% sub('.csv', '', .)))
+
+n_issue_times = length(forecast_issue_times) # there should be n_issue_date files for every model / uncertainty combination
+n_mc = 7500 # number of monte carlo draws
+forecast_project_id = 'GLEON_Bayes_forecast_WG_Gloeo_uncertainty_partition_20200909'
+
+for(m in models){
+  # need to get the different types of uncertainty for given model
+  uncertainty_types = sub('.*?_', '', files[grep(dates[1], files[grep(m, files)])]) %>% sub('\\_.*', '', .)
+  for(u in uncertainty_types){
+    # create a NetCDF for model + uncertainty type for hindcast output
+    forecast_iteration_ids = uuid::UUIDgenerate(n = n_issue_times)
+
+    for(i in 1:length(forecast_issue_times)){
+      # read in csv and store in NetCDF
+      cur_issue_time = forecast_issue_times[i]
+      cur_csv_file = files[grep(cur_issue_time, files[grep(u, files[grep(m, files)])])]
+      cur_hindcast = read.csv(file.path(csv_output_dir, cur_csv_file), stringsAsFactor = F)
+
+      hindcast_df <- select_if(cur_hindcast, ~sum(!is.na(.)) > 0)  %>% # getting rid of NA columns
+        as_tibble()
+
+      n_valid_times <- ncol(hindcast_df) # number of forecast weeks
+      # forecast issue times are at week_0 and week_1-4 are x weeks in the future
+      valid_times <- seq.Date(cur_issue_time + 7,
+                              cur_issue_time + (n_valid_times * 7),
+                              by = 'week')
+
+
+    }
+    # create metadata output for NetCDF
+
+  }
+}
+
+

--- a/5_Model_output/create_netcdfs.R
+++ b/5_Model_output/create_netcdfs.R
@@ -26,7 +26,8 @@ forecast_project_id = 'GLEON_Bayes_forecast_WG_Gloeo_uncertainty_partition_20200
 
 for(m in models){
   # need to get the different types of uncertainty for given model
-  uncertainty_types = sub('.*?_', '', files[grep(forecast_issue_times[1], files[grep(m, files)])]) %>% sub('\\_.*', '', .)
+  model_files = files[grep(m, files)]
+  uncertainty_types = sub('.*?_', '', model_files[grep(forecast_issue_times[1], model_files)]) %>% sub('\\_.*', '', .)
   for(u in uncertainty_types){
     # create a NetCDF for model + uncertainty type for hindcast output
     forecast_iteration_id = uuid::UUIDgenerate()
@@ -40,7 +41,7 @@ for(m in models){
                            n_mc = n_mc,
                            forecast_issue_times = forecast_issue_times,
                            n_valid_times = n_valid_times,
-                           forecast_iteration_id,
+                           forecast_iteration_id = forecast_iteration_id,
                            forecast_project_id = forecast_project_id,
                            model_name = model_name,
                            nc_name_out = nc_name_out)


### PR DESCRIPTION
I pulled out the code for creating NetCDF and EML files into it's own script. This script reads in the hindcast csv files and puts the output into NetCDF along with the necessary model metadata. I combined all forecast issue times together for a given model / uncertainty combination (e.g. all csv output for `AR_IC` are in one NetCDF), which reduced the # of files by 40 going from .csv to NetCDF. Each NetCDF has an associated EML metadata file that describes the forecast and model metadata according to EFI Standards v0.3 ([see document here)](https://docs.google.com/document/d/1Xxyt-1LFHCE-CBwF_qad2sWHMHJoZVJdrOyK4ydjeR0/edit). 

The metadata function is pretty specific to the model and uncertainty combinations that were published on the EDI repository, so if there are new models or new uncertainty combinations that are run for the paper revisions, then this function will likely need to be updated (or will throw an error if it doesn't recognize an uncertainty type). 
@melofton I ran the `create_netcdfs.R` script to see if it works (it does!), but you will have to run this again to create the final output files and once all the final hindcasts are run and complete. There are a couple of things we should update before publishing these on EDI and I tried to put these in comments below. 